### PR TITLE
ipdx: give galargh and laurentsenta admin access as per the contract

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -7,8 +7,10 @@ members:
     - arajasek
     - BigLep
     - filecoin-helper
+    - galargh
     - jbenet
     - jennijuju
+    - laurentsenta
     - mastrwayne-admin
     - mishmosh
     - momack2
@@ -64,7 +66,6 @@ members:
     - filecoin-ci
     - fridrik01
     - frrist
-    - galargh
     - gammazero
     - george-haddad
     - GlacierWalrus


### PR DESCRIPTION
@galargh and @laurentsenta need admin access to the filecoin-project org to complete the IPDX infrastructure migration.