### PR TITLE
fix: making github-mgmt public [skip fix]

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -2264,7 +2264,7 @@ repositories:
       # ATTN: do not add teams with push+ access, use github-mgmt stewards team membership instead
       push:
         - github-mgmt stewards
-    visibility: private
+    visibility: public
   gitops-policy-library:
     archived: true
   gitops-profile-catalog:


### PR DESCRIPTION
https://github.com/filecoin-project/github-mgmt/pull/46 failed to be applied properly because of an issue with security scanning settings.