### PR TITLE
Added rjan90 and rvagg to fvm-crate-owners

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -5048,7 +5048,8 @@ teams:
         - Kubuxu
         - ZenGround0
   fvm-crate-owners:
-    description: Defines ownership of various crates per https://crates.io/teams/github:filecoin-project:fvm-crate-owners
+    description: Defines ownership of various crates per
+      https://crates.io/teams/github:filecoin-project:fvm-crate-owners
     members:
       maintainer:
         - jennijuju

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -5048,6 +5048,7 @@ teams:
         - Kubuxu
         - ZenGround0
   fvm-crate-owners:
+    description: Defines ownership of various crates per https://crates.io/teams/github:filecoin-project:fvm-crate-owners
     members:
       maintainer:
         - jennijuju
@@ -5055,6 +5056,8 @@ teams:
         - Stebalien
       member:
         - magik6k
+        - rjan90
+        - rvagg
   fvm-team:
     members:
       maintainer:


### PR DESCRIPTION
### Summary
Added @rjan90 and @rvagg to [fvm-crate-owners](https://github.com/orgs/filecoin-project/teams/fvm-crate-owners)

### Why do you need this?
This is being done because they're often involved in making releases as part of network upgrades.

### Related
This was triggered when looking at the release process of actors-utils in https://github.com/filecoin-project/actors-utils/pull/235 and ref-fvm in https://github.com/filecoin-project/ref-fvm/pull/2027

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
