### PR TITLE
Temporarily escalate @biglep to org owner

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -4,6 +4,16 @@ members:
   admin:
     - anorth
     - arden-sead
+    # Why @BigLep?
+    # Temporary org ownership is needed to complete https://github.com/filecoin-project/github-mgmt/issues/47
+    # It enables me to
+    # 1. Access the (audit log)[https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/reviewing-the-audit-log-for-your-organization]
+    #    so I can be sure I'm not advocating for removing owner ownership of someone who has been very active on administering the org
+    # 2. Enable me to give the "github-mgmt Stewards" team [moderator](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#organization-moderators) 
+    #    and [security manager](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#security-managers) roles.
+    # Access here will be revoked as part of completing https://github.com/filecoin-project/github-mgmt/issues/47,
+    # which should happen no later than the week of 2024-09-02.
+    - BigLep
     - dr-bizz
     - filecoin-helper
     - galargh
@@ -36,7 +46,6 @@ members:
     - autonome
     - aysmed
     - bajtos
-    - BigLep
     - birdychang
     - BlocksOnAChain
     - bradholden


### PR DESCRIPTION
Temporary org ownership is needed to complete https://github.com/filecoin-project/github-mgmt/issues/47

It enables me to
1. Access the (audit log)[https://docs.github.com/en/organizations/keeping-your-organization-secure/managing-security-settings-for-your-organization/reviewing-the-audit-log-for-your-organization] so I can be sure I'm not advocating for removing owner ownership of someone who has been very active on administering the org
2. Give the "github-mgmt Stewards" team [moderator](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#organization-moderators) and [security manager](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#security-managers) roles.

Access here will be revoked as part of completing https://github.com/filecoin-project/github-mgmt/issues/47, which should happen no later than the week of 2024-09-02.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
