### PR TITLE
Add FIL-B to fevm-contract-tests

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -1038,7 +1038,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -1039,9 +1039,6 @@ repositories:
     allow_update_branch: false
     archived: false
     collaborators:
-      push:
-        - arajasek
-        - maciejwitowski
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -1052,6 +1049,7 @@ repositories:
     teams:
       push:
         - fvm-core-devs
+        - FIL-B
     visibility: public
   fevm-data-dao-kit:
     advanced_security: false

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -1047,8 +1047,8 @@ repositories:
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
       push:
-        - fvm-core-devs
         - FIL-B
+        - fvm-core-devs
     visibility: public
   fevm-data-dao-kit:
     advanced_security: false


### PR DESCRIPTION
### Why do you need this?
I want to assign FIL-B as a reviewer for https://github.com/filecoin-project/fevm-contract-tests/pull/26

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
