### PR TITLE
Remove `pl-deploy-bot` from the org

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -151,7 +151,6 @@ members:
     - patrickwoodhead
     - pk-controller
     - pk13-PLF
-    - pl-deploy-bot
     - porcuquine
     - protocol-labs
     - protocolin
@@ -3195,7 +3194,6 @@ repositories:
       pull:
         - lemmih
         - LesnyRumcajs
-        - pl-deploy-bot
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4050,8 +4048,6 @@ repositories:
     collaborators:
       admin:
         - ognots
-      push:
-        - pl-deploy-bot
     files:
       .github/dependabot.yml:
         content: .github/dependabot.yml
@@ -4750,8 +4746,6 @@ repositories:
     allow_update_branch: false
     archived: false
     collaborators:
-      admin:
-        - pl-deploy-bot
     files:
       .github/dependabot.yml:
         content: .github/dependabot.yml


### PR DESCRIPTION
### Summary
When reviewing the Lotus-Infra repository, which FilOz now maintains, we encountered the `pl-deploy-bot` user. We believe this bot was originally created as part of a GitOps contract between Protocol Labs and Weaveworks.

We've determined that the bot is no longer used in the lotus-infra repository. For security reasons, we recommend removing the pl-deploy-bot user from the organization entirely, and are opening this PR to propose this change and get feedback. If anyone is aware of any current uses for this bot within the organization, please let us know. 

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
