### PR TITLE
Add lanzafame as maintainer of filecoin-docs

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -1374,6 +1374,7 @@ repositories:
       maintain:
         - bobdubois
         - eshon
+        - lanzafame
         - smagdali
         - trruckerfling
       push:


### PR DESCRIPTION
### Summary
As part of work with Filecoin Foundation, lanzafame is helping with managing PRs on docs.filecoin.io.

**DRI:** myself

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
