### PR TITLE
Give @ribaushi triage permissions to lotus

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -3235,9 +3235,9 @@ repositories:
     archived: false
     collaborators:
       maintain:
-        - snadrus
+        - snadrus # Curio lead
       triage:
-        - ribasushi
+        - ribasushi # Independent contributor active on various Lotus issues.  Now can assign labels and leave reviews.
     has_discussions: true
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -3236,6 +3236,8 @@ repositories:
     collaborators:
       maintain:
         - snadrus
+      triage:
+        - ribasushi
     has_discussions: true
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE


### PR DESCRIPTION
This is so @ribasushi can be more self-service in actions like:
* Apply labels to PRs
* Give approval to reviews

### Why do you need this?
@ribasushi is an active Lotus contributor and I want to enable him to be able to apply labels like "skip changelog" or be assigned as a reviewer for something he is collaborating on with a Lotus maintainer.

### What else do we need to know?
Triage permissions for a repo are listed here: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
