### PR TITLE
Temporary write permissions to community repo for Onkar-san

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -668,6 +668,10 @@ repositories:
       push:
         - arajasek
         - dkkapur
+        # Onkar-san's permissions are temporary to enable self-service moderation of https://github.com/filecoin-project/community/discussions/714
+        # See https://docs.github.com/en/communities/moderating-comments-and-conversations/managing-disruptive-comments
+        # This can be removed 2025-01-01.
+        - Onkar-san
         - vnessasgrt
       triage:
         - ec2


### PR DESCRIPTION
### Summary
Onkar-san's permissions are temporary to enable self-service moderation of https://github.com/filecoin-project/community/discussions/714
They need write permissions per https://docs.github.com/en/communities/moderating-comments-and-conversations/managing-disruptive-comments
This can be removed 2025-01-01.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
