### PR TITLE
Created filoz-devguild-mentees team so can assign Lotus issues

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -52,6 +52,7 @@ members:
     - aakoshh
     - aarshkshah1992
     - adlrocha
+    - akaladarshi
     - alanshaw
     - alexandrumatei36
     - Alexey-N-Chernyshov
@@ -190,6 +191,7 @@ members:
     - trruckerfling
     - turuslan
     - vesahc
+    - virajbhartiya
     - vmx
     - vnessasgrt
     - vukolic
@@ -3264,7 +3266,7 @@ repositories:
       maintain:
         - snadrus # Curio lead
       triage:
-        - ribasushi # Independent contributor active on various Lotus issues.  Now can assign labels and leave reviews.
+        - ribasushi # Independent contributor active on various Lotus issues.  Now can assign labels and leave reviews. 
     has_discussions: true
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -3277,6 +3279,8 @@ repositories:
         - lotus-maintainers
       push:
         - lotus-contributors
+      triage:
+        - filoz-devguild-mentees
     visibility: public
   lua-filecoin:
     archived: true
@@ -5024,6 +5028,11 @@ teams:
         - rvagg
         - Stebalien
         - ZenGround0
+  filoz-devguild-mentees:
+    members:
+      member:
+        - akaladarshi
+        - virajbhartiya
   fips-editors:
     members:
       maintainer:

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -5010,6 +5010,11 @@ teams:
       member:
         - kevzak
         - raghavrmadya
+  filoz-devguild-mentees:
+    members:
+      member:
+        - akaladarshi
+        - virajbhartiya
   FilOz:
     members:
       maintainer:
@@ -5028,11 +5033,6 @@ teams:
         - rvagg
         - Stebalien
         - ZenGround0
-  filoz-devguild-mentees:
-    members:
-      member:
-        - akaladarshi
-        - virajbhartiya
   fips-editors:
     members:
       maintainer:


### PR DESCRIPTION
### Why do you need this?
FilOz wants to be able to assign Lotus issues to DevGuild mentees.  

A team was created in case they need to be added to additional repos.

This should make it possible to assign issues to @akaladarshi and @virajbhartiya.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
