### PR TITLE
Make ianconsolata admin of specs

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -4242,11 +4242,11 @@ repositories:
     archived: false
     collaborators:
       admin:
+        - ianconsolata
         - arajasek
         - olizilla
         - yiannisbot
       maintain:
-        - ianconsolata
         - nonsense
         - smagdali
       push:


### PR DESCRIPTION
### Summary
Make me admin of specs repo

### Why do you need this?
I have been the de-facto primary maintainer of this repo since FF started working to get it up to date, and plan to continue administering the repo as part of my work at FF. 

Specifically, I need this access ASAP because deployment is currently broken. An outdated fleek job is attached to the repo and is always failing, preventing deploys. I need admin to manage repo permissions to remove the broken fleek job and change the deploy restrictions to update.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** @ianconsolata, @smagdali 

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [X] It is clear where the request is coming from (if unsure, ask)
- [X] All the automated checks passed
- [X] The YAML changes reflect the summary of the request
- [X] The Terraform plan posted as a comment reflects the summary of the request
