### PR TITLE
add rvagg to fips-editors

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -5091,6 +5091,7 @@ teams:
         - jsoares
         - kaitlin-beegle
         - momack2
+        - rvagg
         - TippyFlitsUK
   Forest:
     members:


### PR DESCRIPTION
Updating to match https://github.com/filecoin-project/FIPs/blob/master/CODEOWNERS so I can merge.

@raulk is missing from this list, would you like me to put you on here too Raul to get these in sync?