### PR TITLE
Add dannyob and lanzafame as org members and members of fips-editors

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -79,11 +79,11 @@ members:
     - Cre-eD
     - cryptoAtwill
     - cryptonemo
+    - dannyob
     - davidad
     - davidd8
     - davidgasquez
     - dchoi27
-    - dannyob
     - DiegoRBaquero
     - dkkapur
     - dnkolegov

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -83,6 +83,7 @@ members:
     - davidd8
     - davidgasquez
     - dchoi27
+    - dannyob
     - DiegoRBaquero
     - dkkapur
     - dnkolegov
@@ -125,6 +126,7 @@ members:
     - kevzak
     - kkarrancsu
     - Kubuxu
+    - lanzafame
     - LaurenSpiegel
     - laurentsenta
     - lemmih
@@ -5083,7 +5085,9 @@ teams:
         - anorth
         - jennijuju
       member:
+        - dannyob
         - jsoares
+        - lanzafame
         - momack2
         - rvagg
         - TippyFlitsUK


### PR DESCRIPTION
This is followup to https://github.com/filecoin-project/github-mgmt/pull/92 which didn't fully apply because @dannyob and @lanzafame are not org members (related backlog item: https://github.com/ipdxco/github-as-code/issues/130 ).  

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
