### PR TITLE
chore: add rjain90 to the github mgmt stewards list

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -5255,7 +5255,10 @@ teams:
         # 2. She is part of the team rather than just relying on "org.admin" abilities so she sees the @filecoin-project/github-mgmt-stewards team mentions/notifications.
         - jennijuju
       member:
-        # Whey @rvagg?
+        # Why @rjain90?
+        # 1. He is a project manager at FilOz.
+        - rjan90
+        # Why @rvagg?
         # 1. He is an active in-the-GitHub-trenches maintainer for FilOz, often touching the 10+ repos that FilOz owns/maintains.
         #    FilOz wants to ensure changes to these repos is done under code review and transparently,
         #    and @rvagg is one of the key people who will be reviewing these changes.


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->
Adds @rjan90 to the github-mgmt stewards team.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->
@rjan90 is often involved in GitHub configuration changes and he would benefit from having merge access in this repository. Example - https://github.com/filecoin-project/github-mgmt/pull/102

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
