### PR TITLE
chore: update perms core-devs repo

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -712,6 +712,7 @@ repositories:
         - relotnek
       maintain:
         - dannyob
+        - rjan90
     has_discussions: true
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -707,13 +707,11 @@ repositories:
     archived: false
     collaborators:
       admin:
-        - arajasek
-        - BlocksOnAChain
         - jennijuju
-        - kaitlin-beegle
         - momack2
+        - relotnek
       maintain:
-        - luckyparadise
+        - dannyob
     has_discussions: true
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE


### PR DESCRIPTION
### Summary
The proposed changes here came up as I was trying to find someone that could give an approval for this PR: https://github.com/filecoin-project/core-devs/pull/192 

### What else do we need to know?
Proposing removing admins that either are no longer in the ecosystem, or has expressed taking a braking from core-devs responsibilities:

**Admin:**
- Removing arajasek: expressed wanting to take a break from core-dev duties here ([link to message in core-devs channel](https://filecoinproject.slack.com/archives/CSC2632KB/p1710943331277889?thread_ts=1710877625.016569&cid=CSC2632KB))
- Removing BlocksOnAChain: left the IPC team in March 2024 (link to message in[ ipc-family](https://filecoinproject.slack.com/archives/C05J93G9G4F/p1709543522065979) channel)
- Removing kaitlin-beegle: does no longer work for the Filecoin Foundation ([link to message in GH](https://github.com/filecoin-project/FIPs/pull/850#issuecomment-2657466603))
- Adding relotnek: works as director of Security at the Filecoin Foundation

 **Maintain:**
 - Removing luckyparadise: resigned from FF. Last work day is 31.March 2025. ([link to post in fil-gov channel](https://filecoinproject.slack.com/archives/C0535S9TUUF/p1742402034381709))
 - Adding dannyob: Senior Fellow at FF. Agreed to be interim maintainer until additional maintainer support is in place ([link to message in core-devs channel](https://filecoinproject.slack.com/archives/CSC2632KB/p1742837795288439?thread_ts=1742802171.224529&cid=CSC2632KB))

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
