### PR TITLE
Remove filecoin-crate-owner from the crate owner teams

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -5179,7 +5179,6 @@ teams:
         - jennijuju
         - magik6k
       member:
-        - filecoin-crate-owner # temporary as part of https://github.com/filecoin-project/github-mgmt/issues/104
         - raulk
         - rjan90
         - rvagg
@@ -5392,7 +5391,6 @@ teams:
       maintainer:
         - jennijuju
       member:
-        - filecoin-crate-owner # temporary as part of https://github.com/filecoin-project/github-mgmt/issues/104
         - Kubuxu
         - rjan90
         - rvagg


### PR DESCRIPTION
### Summary
In this PR, we remove filecoin-crate-owner user from the crate owner teams.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->
This is a follow-up to https://github.com/filecoin-project/github-mgmt/issues/104. filecoin-crate-owner should not require direct access to repositories on GitHub.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->
It was needed for filecoin-crate-owner to be a member of the teams for the process of adjusting the crate ownership on crates.io. This has now been complete, see https://github.com/filecoin-project/github-mgmt/issues/104#issuecomment-2870011733

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
