### PR TITLE
Add lotus-maintainers to all repos with lotus-contributors

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -1206,8 +1206,8 @@ repositories:
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
       push:
-        - lotus-maintainers
         - lotus-contributors
+        - lotus-maintainers
     visibility: private
   fff:
     archived: true

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -794,9 +794,6 @@ repositories:
     advanced_security: false
     allow_update_branch: false
     archived: false
-    collaborators:
-      push:
-        - arajasek
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -805,6 +802,8 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
+      maintain:
+        - lotus-maintainers
       push:
         - bedrock-go
         - lotus-contributors
@@ -1207,6 +1206,7 @@ repositories:
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
       push:
+        - lotus-maintainers
         - lotus-contributors
     visibility: private
   fff:
@@ -1228,6 +1228,8 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
+      maintain:
+        - lotus-maintainers
       push:
         - lotus-contributors
     visibility: public
@@ -2507,6 +2509,8 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
+      maintain:
+        - lotus-maintainers
       push:
         - lotus-contributors
     visibility: public
@@ -3248,6 +3252,8 @@ repositories:
     squash_merge_commit_message: COMMIT_MESSAGES
     squash_merge_commit_title: COMMIT_OR_PR_TITLE
     teams:
+      maintain:
+        - lotus-maintainers
       push:
         - lotus-contributors
     visibility: public
@@ -4194,6 +4200,7 @@ repositories:
       push:
         - infra
         - lotus-contributors
+        - lotus-maintainers
     visibility: public
   sentinel:
     advanced_security: false


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

Make the `lotus-maintainers` group "maintainers" of _most_ repos `lotus-contributors` have access to. I limited them to push access on a few repos that weren't really "lotus centric" (e.g., the bounties).

Please look at the resulting permission changes **CAREFULLY**.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

I removed myself from `lotus-maintainers` and added myself to `lotus-contributors` in https://github.com/filecoin-project/github-mgmt/pull/130 but somehow _gained_ access to the following repos:

>  - will gain push permission to dagstore
>  - will gain push permission to ff-bounties
>  - will gain push permission to ffi-stub
>  - will gain push permission to go-data-transfer
>  - will gain push permission to lotus-docs
>  - will gain push permission to sentinel-tick

This change attempts to put the permissions back in sync.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request