### PR TITLE
Grant FilOzzy required access to Lotus

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -3353,6 +3353,7 @@ repositories:
       admin:
         - lotus-maintainers
       push:
+        - lotus-ci # Credentials for members of this team are used to automate GitHub Release creation 
         - lotus-contributors
       triage:
         - filoz-devguild-mentees
@@ -5271,6 +5272,10 @@ teams:
         - laurentsenta
   legal:
     {}
+  lotus-ci:
+    members:
+      member:
+        - FilOzzy # This account is used to automate GitHub Release creation in Lotus
   lotus-contributors:
     members:
       maintainer:


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->
This PR creates a new lotus-ci team with one member - FilOzzy - and grants it push access to Lotus.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->
This is necessary to be able to create GitHub Releases in Lotus automatically.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->
More specifically, this is needed to be able to allow FilOzzy to create tags in Lotus. Those are created when a GitHub Release is published.

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
