### PR TITLE
Update merkletree perms from maintain to push

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -3273,7 +3273,7 @@ repositories:
     teams:
       admin:
         - proofs-crate-owners
-      maintain:
+      push:
         - proofs
     visibility: public
   meta-aggregator-frontend:


### PR DESCRIPTION
This readds the change from https://github.com/filecoin-project/github-mgmt/pull/137 because it wasn't applied properly.