### PR TITLE
Rename proofs team to proofs-contributors

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -5086,16 +5086,6 @@ teams:
         - raulk
         - whyrusleeping
         - ZenGround0
-  proofs-crate-owners:
-    create_default_maintainer: false
-    members:
-      maintainer:
-        - jennijuju
-      member:
-        - Kubuxu
-        - rjan90
-        - rvagg
-        - ZenGround0
   proofs-contributors:
     members:
       maintainer:
@@ -5107,6 +5097,16 @@ teams:
         - rvagg
         # 202506: not active, but here in case help is needed in 202506+.
         - vmx
+        - ZenGround0
+  proofs-crate-owners:
+    create_default_maintainer: false
+    members:
+      maintainer:
+        - jennijuju
+      member:
+        - Kubuxu
+        - rjan90
+        - rvagg
         - ZenGround0
   research:
     members:


### PR DESCRIPTION
Cleanup item part of https://github.com/filecoin-project/github-mgmt/issues/132

If github mgmt can't handle a rename, we can do the change in the UI and then sync.