### PR TITLE
chore: update the current Forest/ChainSafe members

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -119,6 +119,7 @@ members:
     - ischasny
     - JadTermsani
     - jbenet
+    - jdjaustin # TODO(galargh): Remove the member from the organisation
     - jimpick
     - jnthnvctr
     - joaosa
@@ -132,6 +133,8 @@ members:
     - lanzafame
     - LaurenSpiegel
     - laurentsenta
+    - lemmih # TODO(galargh): Remove the member from the organisation
+    - lerajk # TODO(galargh): Remove the member from the organisation
     - LesnyRumcajs
     - LexLuthr
     - lksbrssr
@@ -164,6 +167,7 @@ members:
     - porcuquine
     - protocol-labs
     - protocolin
+    - q9f # TODO(galargh): Remove the member from the organisation
     - raghavrmadya
     - raulk
     - realChainLife

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -58,6 +58,7 @@ members:
     - alanshaw
     - alexandrumatei36
     - Alexey-N-Chernyshov
+    - AlexeyKrasnoperov
     - AmeanAsad
     - androowoo
     - andyschwab
@@ -109,6 +110,7 @@ members:
     - guanzo
     - guy-goren
     - hammertoe
+    - hanabi1224
     - hannahhoward
     - hunjixin
     - ianconsolata
@@ -117,7 +119,6 @@ members:
     - ischasny
     - JadTermsani
     - jbenet
-    - jdjaustin
     - jimpick
     - jnthnvctr
     - joaosa
@@ -131,8 +132,6 @@ members:
     - lanzafame
     - LaurenSpiegel
     - laurentsenta
-    - lemmih
-    - lerajk
     - LesnyRumcajs
     - LexLuthr
     - lksbrssr
@@ -165,7 +164,6 @@ members:
     - porcuquine
     - protocol-labs
     - protocolin
-    - q9f
     - raghavrmadya
     - raulk
     - realChainLife
@@ -3155,7 +3153,6 @@ repositories:
     archived: false
     collaborators:
       pull:
-        - lemmih
         - LesnyRumcajs
     has_discussions: false
     merge_commit_message: PR_TITLE
@@ -4837,13 +4834,13 @@ teams:
   Forest:
     members:
       maintainer:
-        - lemmih
-        - lerajk
-        - raulk
-      member:
-        - elmattic
+        - kalambet
         - LesnyRumcajs
-        - q9f
+      member:
+        - akaladarshi
+        - AlexeyKrasnoperov
+        - elmattic
+        - hanabi1224
         - sudo-shashank
   foundation:
     members:


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

Updated the list to reflect the current state of ChainSafe/Forest members. In particular:
- `q9f`, `jdjaustin`, `lerajk` no longer work at CS/Forest since 2023,
- `AlexeyKrasnoperov` joined the team this year,
- `lemmih` left the team this year
- `hanabi1224` works in Forest since 2022,
- `kalambet` is the head of engineering at ChainSafe so it makes sense to add him as Forest owner in case I get hit by a bus.

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [x] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
