### PR TITLE
Give rjan90 curio write permissions while TPMing FS

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -762,6 +762,7 @@ repositories:
         - magik6k
       push:
         - aarshkshah1992
+        - rjan90
         - ZenGround0
     has_discussions: true
     merge_commit_message: PR_BODY


### PR DESCRIPTION
This is in support of https://github.com/FilOzone/github-mgmt/issues/10

Alternatively, he could be bumped down to triage permissions, but looking at https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role , my guess is there is going to be a desire for him to have slightly more access so he is self sufficient keeping things organized.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
