### PR TITLE
Add lotus/curio workflow for auto adding PRs and issues to FS project board

### DIFF
--- a/files/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/files/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -1,0 +1,33 @@
+######################################################################################
+# READ THIS FIRST
+# This file is authored in filecoin-project/github-mgmt repository and copied to other repos via automation.
+# If you need to make changes, either:
+# 1. Make the changes in filecoin-project/github-mgmt repository OR
+# 2. Make the changes in the local repo and remove the automated copying from github-mgmt.
+######################################################################################
+
+# This action adds all issues and PRs with a "fs-wg" label to the FS project board.
+# It is used to keep the FS project board up to date with the issues and PRs.
+# It is triggered by the issue and PR events.
+# It assumes a `FILOZZY_CI_ADD_TO_PROJECT` secret is set in the repo.
+# This secret should have the permissions outlined in https://github.com/actions/add-to-project?tab=readme-ov-file#creating-a-pat-and-adding-it-to-your-repository
+name: Add issues and PRs to FS project board
+
+on:
+  issues:
+    types:
+      - labeled
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add all "fs-wg" issues and PRs to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/FilOzone/projects/14
+          github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}
+          labeled: fs-wg

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -764,6 +764,9 @@ repositories:
         - aarshkshah1992
         - rjan90
         - ZenGround0
+    files:
+      .github/workflows/add-issues-and-prs-to-fs-project-board.yml:
+        content: workflows/add-issues-and-prs-to-fs-project-board.yml
     has_discussions: true
     merge_commit_message: PR_BODY
     merge_commit_title: PR_TITLE
@@ -3188,6 +3191,9 @@ repositories:
         - snadrus # Curio lead
       triage:
         - ribasushi # Independent contributor active on various Lotus issues.  Now can assign labels and leave reviews.
+    files:
+      .github/workflows/add-issues-and-prs-to-fs-project-board.yml:
+        content: workflows/add-issues-and-prs-to-fs-project-board.yml
     has_discussions: true
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE


### PR DESCRIPTION
This is part of https://github.com/FilOzone/github-mgmt/issues/10

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
