### PR TITLE
Give lotus-miner-maintainers push access to lotus

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -3207,9 +3207,9 @@ repositories:
       push:
         - lotus-ci # Credentials for members of this team are used to automate GitHub Release creation 
         - lotus-contributors
+        - lotus-miner-maintainers # Push access needed to repo so can make changes in the miner code
       triage:
         - filoz-devguild-mentees
-        - lotus-miner-maintainers
     visibility: public
   lua-filecoin:
     archived: true


### PR DESCRIPTION
This is in response to https://filecoinproject.slack.com/archives/C088QNKCCG6/p1752136854380589 on slack

This should have been done earlier as this team needs to push miner code.

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
