### PR TITLE
smagdali has left FF, so give his permissions to ianconsolata

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -1362,7 +1362,7 @@ repositories:
         - andyschwab
         - jennijuju
         - raulk
-        - smagdali
+        - ianconsolata
       maintain:
         - bobdubois
         - eshon
@@ -1677,7 +1677,6 @@ repositories:
         - filecoinfoundation-inf
         - ianconsolata
         - mirhamasala
-        - smagdali
       maintain:
         - andyschwab
       pull:
@@ -1883,7 +1882,7 @@ repositories:
         - expede
         - hugomrdias
         - maciejwitowski
-        - smagdali
+        - ianconsolata
       maintain:
         - avivash
         - meandavejustice
@@ -1992,7 +1991,7 @@ repositories:
         - LaurenSpiegel
         - rk-rishikesh
         - robertagora
-        - smagdali
+        - ianconsolata
         - xBalbinus
         - XORS-eng
     has_discussions: false
@@ -3378,7 +3377,6 @@ repositories:
         - liuzeming1
         - macro-ss
         - mor9x00
-        - smagdali
         - willpan1102
       maintain:
         - QuietLiu01
@@ -3964,7 +3962,7 @@ repositories:
         - relotnek
       maintain:
         - parthshah1
-        - smagdali
+        - ianconsolata
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4090,7 +4088,6 @@ repositories:
         - mirhamasala
         - nonsense
         - robertagora
-        - smagdali
       push:
         - ognots
     has_discussions: false
@@ -4686,7 +4683,7 @@ teams:
   collab-ff-seo-ux:
     members:
       member:
-        - smagdali
+        - ianconsolata
   collab-ipfs-force:
     members:
       member:
@@ -4767,7 +4764,7 @@ teams:
   docs-storage-provider:
     members:
       member:
-        - smagdali
+        - ianconsolata
   FIL-B:
     members:
       maintainer:
@@ -4833,7 +4830,6 @@ teams:
       maintainer:
         - ianconsolata
         - realChainLife
-        - smagdali
       member:
         - SeedingTrees
         - vnessasgrt
@@ -4946,9 +4942,9 @@ teams:
         #    See https://github.com/ipdxco/github-as-code/issues/126 for more info.)
         # 2. He has experience working with github-mgmt in other contexts (e.g., ipld)
         - rvagg
-        # Why @smagdali?
+        # Why @ianconsolata?
         # 1. Serves as technical projects representative for the Filecoin Foundation.
-        - smagdali
+        - ianconsolata
   infra:
     members:
       member:
@@ -5121,7 +5117,7 @@ teams:
       member:
         - parthshah1
         - relotnek
-        - smagdali
+        - ianconsolata
   Sentinel Admin:
     members:
       maintainer:
@@ -5176,7 +5172,7 @@ teams:
   UXimprovement team:
     members:
       maintainer:
-        - smagdali
+        - mirhamasala
   Venus:
     members:
       maintainer:

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -1360,9 +1360,9 @@ repositories:
     collaborators:
       admin:
         - andyschwab
+        - ianconsolata
         - jennijuju
         - raulk
-        - ianconsolata
       maintain:
         - bobdubois
         - eshon
@@ -1881,8 +1881,8 @@ repositories:
         - eshon
         - expede
         - hugomrdias
-        - maciejwitowski
         - ianconsolata
+        - maciejwitowski
       maintain:
         - avivash
         - meandavejustice
@@ -1987,11 +1987,11 @@ repositories:
       pull:
         - WhiteFlamingo
       push:
+        - ianconsolata
         - jsoares
         - LaurenSpiegel
         - rk-rishikesh
         - robertagora
-        - ianconsolata
         - xBalbinus
         - XORS-eng
     has_discussions: false
@@ -3961,8 +3961,8 @@ repositories:
       admin:
         - relotnek
       maintain:
-        - parthshah1
         - ianconsolata
+        - parthshah1
     has_discussions: false
     merge_commit_message: PR_TITLE
     merge_commit_title: MERGE_MESSAGE
@@ -4932,6 +4932,9 @@ teams:
       member:
         # Why @rjain90?
         # 1. He is a project manager at FilOz.
+        # Why @ianconsolata?
+        # 1. Serves as technical projects representative for the Filecoin Foundation.
+        - ianconsolata
         - rjan90
         # Why @rvagg?
         # 1. He is an active in-the-GitHub-trenches maintainer for FilOz, often touching the 10+ repos that FilOz owns/maintains.
@@ -4942,9 +4945,6 @@ teams:
         #    See https://github.com/ipdxco/github-as-code/issues/126 for more info.)
         # 2. He has experience working with github-mgmt in other contexts (e.g., ipld)
         - rvagg
-        # Why @ianconsolata?
-        # 1. Serves as technical projects representative for the Filecoin Foundation.
-        - ianconsolata
   infra:
     members:
       member:
@@ -5115,9 +5115,9 @@ teams:
     # Filecoin Foundation team members were added 202408 as part of reducing their org ownership in https://github.com/filecoin-project/github-mgmt/issues/47
     members:
       member:
+        - ianconsolata
         - parthshah1
         - relotnek
-        - ianconsolata
   Sentinel Admin:
     members:
       maintainer:

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -4930,11 +4930,11 @@ teams:
         # 2. She is part of the team rather than just relying on "org.admin" abilities so she sees the @filecoin-project/github-mgmt-stewards team mentions/notifications.
         - jennijuju
       member:
-        # Why @rjain90?
-        # 1. He is a project manager at FilOz.
         # Why @ianconsolata?
         # 1. Serves as technical projects representative for the Filecoin Foundation.
         - ianconsolata
+        # Why @rjain90?
+        # 1. He is a project manager at FilOz.
         - rjan90
         # Why @rvagg?
         # 1. He is an active in-the-GitHub-trenches maintainer for FilOz, often touching the 10+ repos that FilOz owns/maintains.


### PR DESCRIPTION
### Summary
@smagdali  is no longer with FF, so I am transferring all his admin responsibilities to me.

### Why do you need this?
I needed admin access to the docs repo to make some changes as the new docs DRI at FF, and realized it was probably best to transfer all of Stef's former permissions to someone senior at FF who can manage access to repos and take over ownership from Stef.

### What else do we need to know?
With Stef departing, @mirhamasala is the new UX / frontend lead for FF, @relotnek is Security lead, and I am focused on tooling and infra. Some of the permissions I am transferring to myself might better be given to @relotnek or @mirhamasala based on the specifics of that repo, so if feel free to leave comments in the review if I am the wrong DRI for a particular repo.

**DRI:** @ianconsolata 
### Reviewer's Checklist
- [x] It is clear where the request is coming from (if unsure, ask)
- [x] All the automated checks passed
- [x] The YAML changes reflect the summary of the request
- [x] The Terraform plan posted as a comment reflects the summary of the request
- [x] Verify with @smagdali that he doesn't need / want access to any of these repos anymore
