### PR TITLE
Update add-issues-and-prs-to-fs-project-board.yml to use pull_request_target

### DIFF
--- a/files/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/files/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -17,7 +17,11 @@ on:
   issues:
     types:
       - labeled
-  pull_request:
+  # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
+  # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
+  # This action does not check out nor execute user code so we should be safe.
+  # We also hardcode to specific hash to ensure no intended changes underneath us.  
+  pull_request_target:
     types:
       - labeled
 
@@ -26,7 +30,7 @@ jobs:
     name: Add all "team/fs-wg" issues and PRs to project
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v1.0.2
+      - uses: actions/add-to-project@244f685bbc3b7adfa8466e08b698b5577571133e # v1.0.2
         with:
           project-url: https://github.com/orgs/FilOzone/projects/14
           github-token: ${{ secrets.FILOZZY_CI_ADD_TO_PROJECT }}

--- a/files/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/files/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -20,7 +20,7 @@ on:
   # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
   # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
   # This action does not check out nor execute user code so we should be safe.
-  # We also hardcode to specific hash to ensure no intended changes underneath us.  
+  # We also hardcode to specific hash to ensure no intended changes underneath us.
   pull_request_target:
     types:
       - labeled

--- a/files/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
+++ b/files/.github/workflows/add-issues-and-prs-to-fs-project-board.yml
@@ -20,7 +20,7 @@ on:
   # Using "pull_request_target" instead of "pull_request" to support PRs from forks.
   # Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input below would otherwise be empty.
   # This action does not check out nor execute user code so we should be safe.
-  # We also hardcode to specific hash to ensure no intended changes underneath us.
+  # We also hardcode to specific hash to ensure no unintended changes underneath us.
   pull_request_target:
     types:
       - labeled


### PR DESCRIPTION
Using "pull_request_target" instead of "pull_request" to support PRs from forks. Workflow runs triggered on PRs from forks do not have access to secrets, so "github-token" input would otherwise be empty. This action does not check out nor execute user code so we should be safe. We also hardcode to specific hash to ensure no intended changes underneath us.  

This should enable runs like https://github.com/filecoin-project/curio/actions/runs/16433720097 to pass

Note that this file is here for reference.  It isn't distributed with github-mgmt currently.