### PR TITLE
Added LesnyRumcajs as an fvm-crate-owner

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -4884,7 +4884,7 @@ teams:
         - jennijuju
         - magik6k
       member:
-        - raulk
+        - LesnyRumcajs
         - rjan90
         - rvagg
   fvm-team:


### PR DESCRIPTION
Relevant since doing FVM-related crate maintainership and needs to be able to do releases (at least until we get more automation in place)

Also removed raulk given he isn't involved with the project currently.