### PR TITLE
Give @Tanisha-fil admin access to community

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -667,9 +667,9 @@ repositories:
     collaborators:
       admin:
         - jennijuju
-        - kaitlin-beegle
         - momack2
         - rjan90
+        - Tanisha-fil
       maintain:
         - eshon
         - trruckerfling


### PR DESCRIPTION
As the one orchestrating nv27, this should enable her to make changes to the locked thread at https://github.com/filecoin-project/community/discussions/74