### PR TITLE
add back `hanabi1224` and `AlexeyKrasnoperov` to org and forest

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -58,6 +58,7 @@ members:
     - alanshaw
     - alexandrumatei36
     - Alexey-N-Chernyshov
+    - AlexeyKrasnoperov
     - AmeanAsad
     - androowoo
     - andyschwab
@@ -109,6 +110,7 @@ members:
     - guanzo
     - guy-goren
     - hammertoe
+    - hanabi1224
     - hannahhoward
     - hunjixin
     - ianconsolata
@@ -4813,8 +4815,10 @@ teams:
         - kalambet
         - LesnyRumcajs
       member:
+        - AlexeyKrasnoperov
         - akaladarshi
         - elmattic
+        - hanabi1224
         - sudo-shashank
   foundation:
     members:

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -4815,8 +4815,8 @@ teams:
         - kalambet
         - LesnyRumcajs
       member:
-        - AlexeyKrasnoperov
         - akaladarshi
+        - AlexeyKrasnoperov
         - elmattic
         - hanabi1224
         - sudo-shashank


### PR DESCRIPTION
### Summary
<!-- include a short summary of the request -->

Not sure why they were removed in https://github.com/filecoin-project/github-mgmt/commit/cb180054ea1402fe95201f52cfeefc3adaf2f8c0 after I added them in https://github.com/filecoin-project/github-mgmt/pull/142. Adding them back; they're active Forest team members.

### Why do you need this?
<!-- include information here which is helpful toward engineers making independent decisions without stakeholders. simple requests may ignore this section, but more complex request should consider what might need to be known in advance and add it -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
