### PR TITLE
Remove aronchick from contributors list

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -64,7 +64,6 @@ members:
     - andyschwab
     - arajasek
     - arden-sead
-    - aronchick
     - art-gor
     - aschmahmann
     - ashwanth-eth


### PR DESCRIPTION
We need to create some more membership headroom.
@aronchick was the first name I saw that I assumed hadn't been active on the project awhile. This was confirmed with https://github.com/search?q=org%3Afilecoin-project+aronchick This is just to alleviate an immediate painpoint.  A more robust cleanup will be done soon in conjunction with IPDX.

I will follow the process at https://github.com/filecoin-project/github-mgmt?tab=readme-ov-file#removing-members-from-the-organization

- [x] (anyone) Open a PR that removes the member from all teams and repositories and leaves a comment next to their name saying they'll be manually removed via the UI. We do this so there is record in the commit history of the intent of the change.
- [ ] ~Get the PR approved per normal process.~
- [x] (github-mgmt-steward) Merge the PR.
- [ ] (org owner) Confirm in https://github.com/filecoin-project/github-mgmt/actions that the actions are applied.
- [ ] (org owner) Access the user in the GitHub UI at https://github.com/orgs/filecoin-project/people/USERNAME
- [ ] (org owner) Remove the user from the organization via the "Remove from organization" button.
- [ ] (org owner) Grab a screenshot
- [ ] (org owner) [Run the sync workflow](https://github.com/filecoin-project/github-mgmt/actions/workflows/sync.yml) to remove the user from the terraform state
- [ ] (org owner) Post back in the original PR that the user has been fully removed, including the screenshot and a link to the sync workflow run.