### PR TITLE
Update filecoin-project.yml

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -678,6 +678,11 @@ repositories:
         - arajasek
         - dkkapur
         - vnessasgrt
+        - Onkar-san
+        # Onkar-san's permissions are temporary to enable self-service moderation of https://github.com/filecoin-project/community/discussions/744 
+        # They need write permissions per https://docs.github.com/en/communities/moderating-comments-and-conversations/managing-disruptive-comments 
+        # This can be removed 2025-12-01 (1st December, 2025).
+
       triage:
         - ec2
         - haochizzle


### PR DESCRIPTION
Adding community manager permissions to Onkar-san temporarily.

Summary
Onkar-san's permissions are temporary to enable self-service moderation of https://github.com/filecoin-project/community/discussions/744

They need write permissions per https://docs.github.com/en/communities/moderating-comments-and-conversations/managing-disruptive-comments

This can be removed 2025-12-01 (1st December, 2025).

### Why do you need this?
<!-- Opening a locked discussion thread and later closing it, and moderating comments on the discussion. -->

### What else do we need to know?
<!-- any details required to complete the request? are there any special concerns to consider? priority, confidentiality, deadlines, etc -->

**DRI:** myself, @BigLep 

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
