### PR TITLE
Moving some users to be outside collaborators

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -144,7 +144,6 @@ members:
     - masih
     - masterjedy
     - matejpavlovic
-    - mb1896
     - MF416
     - Mingela
     - mirhamasala
@@ -163,7 +162,6 @@ members:
     - patrickwoodhead
     - pk-controller
     - pk13-PLF
-    - porcuquine
     - protocol-labs
     - protocolin
     - raghavrmadya
@@ -180,7 +178,6 @@ members:
     - SeedingTrees
     - sergkaprovich
     - simonkim0515
-    - smagdali
     - smooth-operator
     - snadrus
     - snissn
@@ -191,7 +188,6 @@ members:
     - tediou5
     - Terryhung
     - TheDivic
-    - TheMenko
     - TippyFlitsUK
     - TorfinnOlsen
     - trruckerfling
@@ -210,7 +206,6 @@ members:
     - xmcai2016
     - XORS-eng
     - yiannisbot
-    - YuliiaFilecoin
     - ZenGround0
     - zixuanzh
     - zuiris


### PR DESCRIPTION
These users were listed as organizational members but they're not part of a team or any repo.  As a result, they should be 100% safe to move as outside collaborators in the organization.  I will do that in the UI, since there isn't a way to do this through github-mgmt currently.  I'm doing this to free up membership seats for folks who do need to be members so they can access private repos.

@TheMenko
@YuliiaFilecoin
@mb1896
@porcuquine
@smagdali