### PR TITLE
Replace supragya with bambooogreen

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -70,6 +70,7 @@ members:
     - autonome
     - aysmed
     - bajtos
+    - bambooogreen
     - birdychang
     - BlocksOnAChain
     - bradholden
@@ -183,7 +184,6 @@ members:
     - Stefaan-V
     - steven004
     - sudo-shashank
-    - supragya
     - tediou5
     - Terryhung
     - TheDivic
@@ -4876,6 +4876,7 @@ teams:
         - jennijuju
         - TippyFlitsUK
       member:
+        - bambooogreen
         - irenegia
         - Kubuxu
         - lucaniz
@@ -4883,7 +4884,6 @@ teams:
         - nicola
         - rjan90
         - rvagg
-        - supragya
         - wjmelements
         - ZenGround0
   fips-editors:


### PR DESCRIPTION
Using preferred github account for filecoin work

This is followup to https://github.com/filecoin-project/github-mgmt/pull/172 as requested by @bambooogreen