### PR TITLE
chore: Give StorSwift-members push access to Lotus

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -3406,6 +3406,9 @@ repositories:
     collaborators:
       maintain:
         - snadrus # Curio lead
+      push:
+        - marco-storswift # StorSwift team members, that are maintaining lotus-miner
+        - snail8501 # StorSwift team members, that are maintaining lotus-miner
       triage:
         - ribasushi # Independent contributor active on various Lotus issues.  Now can assign labels and leave reviews.
     has_discussions: true

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -3406,9 +3406,6 @@ repositories:
     collaborators:
       maintain:
         - snadrus # Curio lead
-      push:
-        - marco-storswift # StorSwift team members, that are maintaining lotus-miner
-        - snail8501 # StorSwift team members, that are maintaining lotus-miner
       triage:
         - ribasushi # Independent contributor active on various Lotus issues.  Now can assign labels and leave reviews.
     has_discussions: true
@@ -5210,6 +5207,9 @@ teams:
     members:
       maintainer:
         - tediou5
+      member:
+        - marco-storswift # StorSwift team members, that are maintaining lotus-miner
+        - snail8501 # StorSwift team members, that are maintaining lotus-miner
   moderators:
     # Assigning this team the Moderator role is configured through the GitHub UI, not in github-mgmt.
     # Sead team members were added 202408 as part of reducing their org ownership in https://github.com/filecoin-project/github-mgmt/issues/47


### PR DESCRIPTION
### Why do you need this?
StorSwift maintains Lotus-Miner

**DRI:** myself
<!-- we would like someone to contact in the event we don't know what to do next. if this is not you, please update this. in case of access request, please tag someone who's aware of your access needs -->

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
