### PR TITLE
chore: add rvagg as code-owner in curio

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -4918,6 +4918,7 @@ teams:
       member:
         - LexLuthr
         - Reiers
+        - rvagg
   Data Programs:
     members:
       maintainer:

--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -4913,10 +4913,10 @@ teams:
   Curio:
     members:
       maintainer:
+        - LexLuthr
         - magik6k
         - snadrus
       member:
-        - LexLuthr
         - Reiers
         - rvagg
   Data Programs:


### PR DESCRIPTION


### Summary
Add rvagg as code-owner in curio. Ref: https://filecoinproject.slack.com/archives/C08TVNKJV7C/p1779956569108749

### Reviewer's Checklist
<!-- TO BE COMPLETED BY THE REVIEWER -->
- [ ] It is clear where the request is coming from (if unsure, ask)
- [ ] All the automated checks passed
- [ ] The YAML changes reflect the summary of the request
- [ ] The Terraform plan posted as a comment reflects the summary of the request
