### PR TITLE
fix: grant FilOzzy admin access to filecoin-pin

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -1589,6 +1589,7 @@ repositories:
     archived: false
     collaborators:
       admin:
+        - FilOzzy
         - juliangruber
         - rvagg
         - SgtPooki
@@ -1600,7 +1601,6 @@ repositories:
         - beck-8
         - BravoNatalie
         - davidgasquez
-        - FilOzzy
         - geomatrick
         - hugomrdias
         - juliangruber


### PR DESCRIPTION
## Summary
- Grant `FilOzzy` admin access on `filecoin-project/filecoin-pin`.
- Move `FilOzzy` from push access to admin access.

Ref: https://github.com/FilOzone/tpm-utils/issues/16#issuecomment-4665035202