### PR TITLE
fix: remove duplicate filecoin-pin collaborator

### DIFF
--- a/github/filecoin-project.yml
+++ b/github/filecoin-project.yml
@@ -1603,7 +1603,6 @@ repositories:
         - davidgasquez
         - geomatrick
         - hugomrdias
-        - juliangruber
         - lidel
         - pyropy
         - ravish1729


### PR DESCRIPTION
## Summary
- remove `juliangruber` from the `filecoin-pin` push collaborators because they are already listed as admin
- keep both `FilOzzy` and `juliangruber` as admin-only entries for `filecoin-pin`

## Context
This fixes the Terraform duplicate object key failure from the Apply run after #211 merged:
https://github.com/filecoin-project/github-mgmt/actions/runs/27330972116/job/80743094826

Terraform reported the duplicate key as `filecoin-pin:juliangruber`.

## Validation
- `ruby -ryaml -e 'cfg=YAML.load_file("github/filecoin-project.yml"); c=cfg.dig("repositories","filecoin-pin","collaborators") || {}; %w[FilOzzy juliangruber].each { |u| raise "#{u} missing admin" unless (c["admin"] || []).include?(u); %w[maintain push triage pull].each { |p| raise "#{u} duplicate #{p}" if (c[p] || []).include?(u) } }; puts "filecoin-pin admin-only collaborators OK"'`\n- `git diff --check`